### PR TITLE
compile time options for HIDE_SOCKET_FILENO and FAST_CONNECT_DROP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ ENV/
 # Pyenet specific files
 enet.c
 enet/
+config.pxi

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,26 @@ from Cython.Distutils import build_ext
 
 import glob
 import sys
+import os
 
-source_files = ["enet.pyx"]
+compile_options = {
+  'hide_socket_fileno': False,
+  'fast_connect_drop': False,
+}
+
+if "--enable-hide-socket-fileno" in sys.argv:
+    compile_options["hide_socket_fileno"] = True
+    sys.argv.remove("--enable-hide-socket-fileno")
+if "--enable-fast-connect-drop" in sys.argv:
+    compile_options["fast_connect_drop"] = True
+    sys.argv.remove("--enable-fast-connect-drop")
+
+with open(os.path.join(os.path.dirname(__file__), 'config.pxi'), 'w') as fd:
+    for k, v in compile_options.items():
+        fd.write('DEF %s = %d\n' % (k.upper(), int(v)))
+
+
+source_files = ["enet.pyx", "config.pxi"]
 
 _enet_files = glob.glob("enet/*.c")
 


### PR DESCRIPTION
Enables to hide Socket.fileno function (from external SDK for example, so it wouldn't be possible to abuse the underlying Socket connection instead of using intercept callback properly)

As well as fast Connect Drop where it can return None instead of the event on disconnect of the peer.

Enabled through compile time options in setup.py.

Tested it with py2k and py3k, works fine.

Voice the concern if you have any :-)